### PR TITLE
Month 정보 불러오기 (선형회귀 그래프)

### DIFF
--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/controller/GraphController.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/controller/GraphController.java
@@ -2,6 +2,7 @@ package com.tukorea.turtleneck.backend.domain.health.controller;
 
 
 import com.tukorea.turtleneck.backend.domain.health.dto.DayGraphInfo;
+import com.tukorea.turtleneck.backend.domain.health.dto.MonthGraphInfo;
 import com.tukorea.turtleneck.backend.domain.health.dto.WeekGraphInfo;
 import com.tukorea.turtleneck.backend.domain.health.service.GraphService;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,13 @@ public class GraphController {
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         return ResponseEntity.ok().body(graphService.getWeekGraphInfo(date, nickname));
+    }
+
+    @GetMapping("/month")
+    public ResponseEntity<MonthGraphInfo> getMonthGraph(
+            @RequestParam String nickname,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return ResponseEntity.ok().body(graphService.getMonthGraphInfo(date, nickname));
     }
 }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/dto/DayInfo.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/dto/DayInfo.java
@@ -1,0 +1,11 @@
+package com.tukorea.turtleneck.backend.domain.health.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DayInfo {
+    private int x;
+    private long y;
+}

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/dto/MonthGraphInfo.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/dto/MonthGraphInfo.java
@@ -1,0 +1,12 @@
+package com.tukorea.turtleneck.backend.domain.health.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class MonthGraphInfo {
+    private List<DayInfo> infoList;
+}

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/dto/WeekGraphInfo.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/dto/WeekGraphInfo.java
@@ -1,11 +1,15 @@
 package com.tukorea.turtleneck.backend.domain.health.dto;
 
 
-import lombok.Builder;
+import com.tukorea.turtleneck.backend.domain.health.domain.HealthInfo;
+import com.tukorea.turtleneck.backend.domain.health.service.util.GraphTool;
+import com.tukorea.turtleneck.backend.domain.health.service.util.WeekOfDay;
 import lombok.Data;
 
+import java.util.List;
+import java.util.Map;
+
 @Data
-@Builder
 public class WeekGraphInfo {
     private Long mon;
     private Long tue;
@@ -14,4 +18,14 @@ public class WeekGraphInfo {
     private Long fri;
     private Long sat;
     private Long sun;
+
+    public WeekGraphInfo(Map<WeekOfDay, List<HealthInfo>> map) {
+        this.mon = GraphTool.calculatePortion(map.get(WeekOfDay.MONDAY));
+        this.tue = GraphTool.calculatePortion(map.get(WeekOfDay.TUESDAY));
+        this.wed = GraphTool.calculatePortion(map.get(WeekOfDay.WEDNESDAY));
+        this.thu = GraphTool.calculatePortion(map.get(WeekOfDay.THURSDAY));
+        this.fri = GraphTool.calculatePortion(map.get(WeekOfDay.FRIDAY));
+        this.sat = GraphTool.calculatePortion(map.get(WeekOfDay.SATURDAY));
+        this.sun = GraphTool.calculatePortion(map.get(WeekOfDay.SUNDAY));
+    }
 }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/GraphService.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/GraphService.java
@@ -4,6 +4,8 @@ package com.tukorea.turtleneck.backend.domain.health.service;
 import com.tukorea.turtleneck.backend.domain.health.dao.HealthRepository;
 import com.tukorea.turtleneck.backend.domain.health.domain.HealthInfo;
 import com.tukorea.turtleneck.backend.domain.health.dto.DayGraphInfo;
+import com.tukorea.turtleneck.backend.domain.health.dto.DayInfo;
+import com.tukorea.turtleneck.backend.domain.health.dto.MonthGraphInfo;
 import com.tukorea.turtleneck.backend.domain.health.dto.WeekGraphInfo;
 import com.tukorea.turtleneck.backend.domain.health.service.util.GraphTool;
 import com.tukorea.turtleneck.backend.domain.health.service.util.WeekOfDay;
@@ -61,5 +63,17 @@ public class GraphService {
             }
         }
         return new WeekGraphInfo(map);
+    }
+
+    public MonthGraphInfo getMonthGraphInfo(LocalDate date, String nickname){
+        MemberEntity memberEntity = memberRepository.findMemberEntityByNickname(nickname)
+                .orElseThrow(NotFoundMemberException::new);
+        List<DayInfo> infoList = new ArrayList<>();
+        for(int i = 1; i <= date.lengthOfMonth(); i++){
+            LocalDate nowDate = date.withDayOfMonth(i);
+            double average = GraphTool.calculateAverage(healthRepository.findByDay(memberEntity, nowDate));
+            infoList.add(DayInfo.builder().x(i).y((long) average).build());
+        }
+        return MonthGraphInfo.builder().infoList(infoList).build();
     }
 }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/GraphService.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/GraphService.java
@@ -32,7 +32,7 @@ public class GraphService {
         MemberEntity memberEntity = memberRepository.findMemberEntityByNickname(nickname)
                 .orElseThrow(NotFoundMemberException::new);
         List<HealthInfo> infoList = healthRepository.findByDay(memberEntity, date);
-        long portion = tools.calculatePortion(infoList);
+        long portion = GraphTool.calculatePortion(infoList);
         return DayGraphInfo.builder().portion(portion).build();
     }
 
@@ -51,23 +51,15 @@ public class GraphService {
         }
         for(HealthInfo info : infoList) {
             switch (info.getDate().getDayOfWeek()) {
-                case MONDAY: tools.addHealthInfo(map, WeekOfDay.MONDAY, info); break;
-                case TUESDAY: tools.addHealthInfo(map, WeekOfDay.TUESDAY, info); break;
-                case WEDNESDAY: tools.addHealthInfo(map, WeekOfDay.WEDNESDAY, info); break;
-                case THURSDAY: tools.addHealthInfo(map, WeekOfDay.THURSDAY, info); break;
-                case FRIDAY: tools.addHealthInfo(map, WeekOfDay.FRIDAY, info); break;
-                case SATURDAY: tools.addHealthInfo(map, WeekOfDay.SATURDAY, info); break;
-                case SUNDAY: tools.addHealthInfo(map, WeekOfDay.SUNDAY, info); break;
+                case MONDAY: GraphTool.addHealthInfo(map, WeekOfDay.MONDAY, info); break;
+                case TUESDAY: GraphTool.addHealthInfo(map, WeekOfDay.TUESDAY, info); break;
+                case WEDNESDAY: GraphTool.addHealthInfo(map, WeekOfDay.WEDNESDAY, info); break;
+                case THURSDAY: GraphTool.addHealthInfo(map, WeekOfDay.THURSDAY, info); break;
+                case FRIDAY: GraphTool.addHealthInfo(map, WeekOfDay.FRIDAY, info); break;
+                case SATURDAY: GraphTool.addHealthInfo(map, WeekOfDay.SATURDAY, info); break;
+                case SUNDAY: GraphTool.addHealthInfo(map, WeekOfDay.SUNDAY, info); break;
             }
         }
-        return WeekGraphInfo.builder()
-                .mon(tools.calculatePortion(map.get(WeekOfDay.MONDAY)))
-                .tue(tools.calculatePortion(map.get(WeekOfDay.TUESDAY)))
-                .wed(tools.calculatePortion(map.get(WeekOfDay.WEDNESDAY)))
-                .thu(tools.calculatePortion(map.get(WeekOfDay.THURSDAY)))
-                .fri(tools.calculatePortion(map.get(WeekOfDay.FRIDAY)))
-                .sat(tools.calculatePortion(map.get(WeekOfDay.SATURDAY)))
-                .sun(tools.calculatePortion(map.get(WeekOfDay.SUNDAY)))
-                .build();
+        return new WeekGraphInfo(map);
     }
 }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/GraphService.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/GraphService.java
@@ -5,6 +5,8 @@ import com.tukorea.turtleneck.backend.domain.health.dao.HealthRepository;
 import com.tukorea.turtleneck.backend.domain.health.domain.HealthInfo;
 import com.tukorea.turtleneck.backend.domain.health.dto.DayGraphInfo;
 import com.tukorea.turtleneck.backend.domain.health.dto.WeekGraphInfo;
+import com.tukorea.turtleneck.backend.domain.health.service.util.GraphTool;
+import com.tukorea.turtleneck.backend.domain.health.service.util.WeekOfDay;
 import com.tukorea.turtleneck.backend.domain.member.dao.MemberRepository;
 import com.tukorea.turtleneck.backend.domain.member.domain.MemberEntity;
 import com.tukorea.turtleneck.backend.domain.member.exception.NotFoundMemberException;
@@ -24,12 +26,13 @@ import java.util.Map;
 public class GraphService {
     private final HealthRepository healthRepository;
     private final MemberRepository memberRepository;
+    private final GraphTool tools;
 
     public DayGraphInfo getDayGraphInfo(LocalDate date, String nickname){
         MemberEntity memberEntity = memberRepository.findMemberEntityByNickname(nickname)
                 .orElseThrow(NotFoundMemberException::new);
         List<HealthInfo> infoList = healthRepository.findByDay(memberEntity, date);
-        long portion = calculatePortion(infoList);
+        long portion = tools.calculatePortion(infoList);
         return DayGraphInfo.builder().portion(portion).build();
     }
 
@@ -48,62 +51,23 @@ public class GraphService {
         }
         for(HealthInfo info : infoList) {
             switch (info.getDate().getDayOfWeek()) {
-                case MONDAY:
-                    addHealthInfo(map, WeekOfDay.MONDAY, info);
-                    break;
-                case TUESDAY:
-                    addHealthInfo(map, WeekOfDay.TUESDAY, info);
-                    break;
-                case WEDNESDAY:
-                    addHealthInfo(map, WeekOfDay.WEDNESDAY, info);
-                    break;
-                case THURSDAY:
-                    addHealthInfo(map, WeekOfDay.THURSDAY, info);
-                    break;
-                case FRIDAY:
-                    addHealthInfo(map, WeekOfDay.FRIDAY, info);
-                    break;
-                case SATURDAY:
-                    addHealthInfo(map, WeekOfDay.SATURDAY, info);
-                    break;
-                case SUNDAY:
-                    addHealthInfo(map, WeekOfDay.SUNDAY, info);
-                    break;
+                case MONDAY: tools.addHealthInfo(map, WeekOfDay.MONDAY, info); break;
+                case TUESDAY: tools.addHealthInfo(map, WeekOfDay.TUESDAY, info); break;
+                case WEDNESDAY: tools.addHealthInfo(map, WeekOfDay.WEDNESDAY, info); break;
+                case THURSDAY: tools.addHealthInfo(map, WeekOfDay.THURSDAY, info); break;
+                case FRIDAY: tools.addHealthInfo(map, WeekOfDay.FRIDAY, info); break;
+                case SATURDAY: tools.addHealthInfo(map, WeekOfDay.SATURDAY, info); break;
+                case SUNDAY: tools.addHealthInfo(map, WeekOfDay.SUNDAY, info); break;
             }
         }
         return WeekGraphInfo.builder()
-                .mon(calculatePortion(map.get(WeekOfDay.MONDAY)))
-                .tue(calculatePortion(map.get(WeekOfDay.TUESDAY)))
-                .wed(calculatePortion(map.get(WeekOfDay.WEDNESDAY)))
-                .thu(calculatePortion(map.get(WeekOfDay.THURSDAY)))
-                .fri(calculatePortion(map.get(WeekOfDay.FRIDAY)))
-                .sat(calculatePortion(map.get(WeekOfDay.SATURDAY)))
-                .sun(calculatePortion(map.get(WeekOfDay.SUNDAY)))
+                .mon(tools.calculatePortion(map.get(WeekOfDay.MONDAY)))
+                .tue(tools.calculatePortion(map.get(WeekOfDay.TUESDAY)))
+                .wed(tools.calculatePortion(map.get(WeekOfDay.WEDNESDAY)))
+                .thu(tools.calculatePortion(map.get(WeekOfDay.THURSDAY)))
+                .fri(tools.calculatePortion(map.get(WeekOfDay.FRIDAY)))
+                .sat(tools.calculatePortion(map.get(WeekOfDay.SATURDAY)))
+                .sun(tools.calculatePortion(map.get(WeekOfDay.SUNDAY)))
                 .build();
-    }
-
-    private long calculatePortion(List<HealthInfo> infoList) {
-        if(infoList.isEmpty()){
-            return 0;
-        }
-        double redCnt = 0.0;
-        double yellowCnt = 0.0;
-        double greenCnt = 0.0;
-        for(HealthInfo info : infoList){
-            redCnt = redCnt + info.getRedCnt();
-            yellowCnt = yellowCnt + info.getYellowCnt();
-            greenCnt = greenCnt + info.getGreenCnt();
-        }
-        double portion =  ((redCnt + yellowCnt) / (redCnt + yellowCnt + greenCnt)) * 100;
-        return (long) portion;
-    }
-
-    private enum WeekOfDay {
-        MONDAY, TUESDAY, THURSDAY, WEDNESDAY, FRIDAY, SATURDAY, SUNDAY
-    }
-
-    private void addHealthInfo(Map<WeekOfDay, List<HealthInfo>> map, WeekOfDay day, HealthInfo healthInfo) {
-        List<HealthInfo> list = map.get(day);
-        list.add(healthInfo);
     }
 }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/GraphTool.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/GraphTool.java
@@ -1,0 +1,29 @@
+package com.tukorea.turtleneck.backend.domain.health.service.util;
+
+import com.tukorea.turtleneck.backend.domain.health.domain.HealthInfo;
+
+import java.util.List;
+import java.util.Map;
+
+public class GraphTool {
+
+    public long calculatePortion(List<HealthInfo> infoList) {
+        if(infoList.isEmpty()){
+            return 0;
+        }
+        double redCnt = 0.0;
+        double yellowCnt = 0.0;
+        double greenCnt = 0.0;
+        for(HealthInfo info : infoList){
+            redCnt = redCnt + info.getRedCnt();
+            yellowCnt = yellowCnt + info.getYellowCnt();
+            greenCnt = greenCnt + info.getGreenCnt();
+        }
+        double portion =  ((redCnt + yellowCnt) / (redCnt + yellowCnt + greenCnt)) * 100;
+        return (long) portion;
+    }
+    public void addHealthInfo(Map<WeekOfDay, List<HealthInfo>> map, WeekOfDay day, HealthInfo healthInfo) {
+        List<HealthInfo> list = map.get(day);
+        list.add(healthInfo);
+    }
+}

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/GraphTool.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/GraphTool.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class GraphTool {
 
-    public long calculatePortion(List<HealthInfo> infoList) {
+    public static long calculatePortion(List<HealthInfo> infoList) {
         if(infoList.isEmpty()){
             return 0;
         }
@@ -22,7 +22,7 @@ public class GraphTool {
         double portion =  ((redCnt + yellowCnt) / (redCnt + yellowCnt + greenCnt)) * 100;
         return (long) portion;
     }
-    public void addHealthInfo(Map<WeekOfDay, List<HealthInfo>> map, WeekOfDay day, HealthInfo healthInfo) {
+    public static void addHealthInfo(Map<WeekOfDay, List<HealthInfo>> map, WeekOfDay day, HealthInfo healthInfo) {
         List<HealthInfo> list = map.get(day);
         list.add(healthInfo);
     }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/GraphTool.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/GraphTool.java
@@ -1,12 +1,13 @@
 package com.tukorea.turtleneck.backend.domain.health.service.util;
 
 import com.tukorea.turtleneck.backend.domain.health.domain.HealthInfo;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
 
+@Component
 public class GraphTool {
-
     public static long calculatePortion(List<HealthInfo> infoList) {
         if(infoList.isEmpty()){
             return 0;
@@ -25,5 +26,20 @@ public class GraphTool {
     public static void addHealthInfo(Map<WeekOfDay, List<HealthInfo>> map, WeekOfDay day, HealthInfo healthInfo) {
         List<HealthInfo> list = map.get(day);
         list.add(healthInfo);
+    }
+
+    public static long calculateAverage(List<HealthInfo> infoList) {
+        if(infoList.isEmpty()){
+            return 0;
+        }
+        double totalGreen = 0, totalYellow = 0, totalRed = 0;
+        for (HealthInfo info : infoList) {
+            totalGreen += info.getGreenCnt();
+            totalYellow += info.getYellowCnt();
+            totalRed += info.getRedCnt();
+        }
+        double userData = (10 * totalGreen + 27 * totalYellow + 60 * totalRed) /  97.0;
+//        double result = (1.0 / userData) * 100;
+        return (long) userData;
     }
 }

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/WeekOfDay.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/health/service/util/WeekOfDay.java
@@ -1,0 +1,5 @@
+package com.tukorea.turtleneck.backend.domain.health.service.util;
+
+public enum WeekOfDay {
+    MONDAY, TUESDAY, THURSDAY, WEDNESDAY, FRIDAY, SATURDAY, SUNDAY
+}

--- a/src/main/java/com/tukorea/turtleneck/backend/domain/member/domain/MemberEntity.java
+++ b/src/main/java/com/tukorea/turtleneck/backend/domain/member/domain/MemberEntity.java
@@ -20,13 +20,13 @@ public class MemberEntity extends BaseEntity {
     @Column(name = "member_id")
     private Long memberid;
 
-    @Column(name = "email")
+    @Column(name = "email", unique = true)
     private String emailId;
 
     @Column(name = "password")
     private String password;
 
-    @Column(name = "nickname")
+    @Column(name = "nickname", unique = true)
     private String nickname;
 
     @Column(name = "turtleneck_status")


### PR DESCRIPTION
## 추가한 기능 설명
<img width="1002" alt="image" src="https://github.com/Turtle-Neck-Saivor/backend/assets/57928967/3e0706c7-5c3c-4089-a235-2be1bfa6171b">

$$
User\space Data=\frac{10\sum_{i=1}^{n}G_i\space+\space27\sum_{i=1}^{m}Y_i\space+\space60\sum_{i=1}^{k}R_i}{10+27+60}
$$

한달 동안 일별로 구한 가중 평균 리스트를 반환
가중 평균 수식은 위와 같음

<br>


## check list
- [ ] issue number를 브랜치 앞에 추가 하였는가?
- [ ] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
- [ ] [우테코 pr 규칙](https://github.com/woowacourse/woowacourse-docs/blob/master/cleancode/pr_checklist.md)을 준수하였는가?